### PR TITLE
add  null filter for include and exclude 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastcampus/fastdao",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "fast and simple dao using knex",
   "url": "https://github.com/fastcampusgit/fastdao",
   "repository": "https://github.com/fastcampusgit/fastdao",

--- a/src/crud-operations.spec.ts
+++ b/src/crud-operations.spec.ts
@@ -47,6 +47,12 @@ describe('crud-operations', () => {
       console.log(rows);
       expect(rows).toMatchObject(await knex('post').whereIn('id', [1, 3]).select());
     });
+    it('should select with include/exclude null filter', async () => {
+      const rows1 = await postCrud.select({ include: { id: [9, 10], linked_post_id: null } });
+      expect(rows1).toMatchObject(await knex('post').whereIn('id', [9]).select());
+      const rows2 = await postCrud.select({ include: { id: [9, 10] }, exclude: { linked_post_id: null } });
+      expect(rows2).toMatchObject(await knex('post').whereIn('id', [10]).select());
+    });
     it('should select with min/max filter', async () => {
       const rows = await postCrud.select({ min: 1, max: 4 });
       expect(rows).toMatchObject(await knex('post').whereIn('id', [1, 2, 3]).select());

--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -3,7 +3,7 @@ import * as Knex from 'knex';
 import { SortOrder, Sort, parseSorts } from './sort';
 import { Relation, parseRelations } from './relation';
 import { Weaver } from './weaver';
-import { canExactMatch, canExactMatchIn } from './util';
+import { canExactMatch, canExactMatchIn, isNull } from './util';
 
 export interface CrudFilter<ID = number, ROW = any> {
   // for exact match
@@ -218,6 +218,8 @@ export class CrudOperations<ID = number, ROW = any>
           queryBuilder.whereNot(this.columnName(key), value);
         } else if (canExactMatchIn(value)) {
           queryBuilder.whereNotIn(this.columnName(key), value as Array<any>);
+        } else if (isNull(value)) {
+          queryBuilder.whereNotNull(this.columnName(key));
         }
       }
     }
@@ -227,6 +229,8 @@ export class CrudOperations<ID = number, ROW = any>
           queryBuilder.where(this.columnName(key), value);
         } else if (canExactMatchIn(value)) {
           queryBuilder.whereIn(this.columnName(key), value as Array<any>);
+        } else if (isNull(value)) {
+          queryBuilder.whereNull(this.columnName(key));
         }
       }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,3 +5,7 @@ export const canExactMatch = (value) => {
 export const canExactMatchIn = (value) => {
   return Array.isArray(value) && value.length > 0 && value.every((it) => canExactMatch(it));
 };
+
+export const isNull = (value) => {
+  return value === null;
+};

--- a/test/migrations/20200701000020_post.ts
+++ b/test/migrations/20200701000020_post.ts
@@ -10,6 +10,7 @@ export async function up(knex: Knex): Promise<void> {
     t.string('content');
     t.integer('forum_id').notNullable();
     t.integer('user_id').notNullable();
+    t.integer('linked_post_id').nullable();
     //t.foreign('forum_id').references('id').inTable('forum');
     //t.foreign('user_id').references('id').inTable('user');
   });

--- a/test/seeds/post.ts
+++ b/test/seeds/post.ts
@@ -13,5 +13,6 @@ export async function seed(knex: Knex): Promise<void> {
     { id: 7, type: 'POST', state: 'NORMAL', title: 'p7', content: 'p7 f1 u3', forum_id: 1, user_id: 3 },
     { id: 8, type: 'POST', state: 'NORMAL', title: 'p8', content: 'p8 f2 u3', forum_id: 2, user_id: 3 },
     { id: 9, type: 'POST', state: 'DELETED', title: 'p9', content: 'p9 f3 u3', forum_id: 3, user_id: 3 },
+    { id: 10, type: 'POST', state: 'NORMAL', title: 'p10', content: 'p10 f3 u3', forum_id: 3, user_id: 3, linked_post_id: 1 },
   ]);
 }


### PR DESCRIPTION
fastdao 의 기본 데이터 모델이 notNullable 을 기준으로 구성되어 있는데 현실에서 이게 지켜지지 않을 경우도 있어 nullable 상태의 필드에 대한 필터를 추가해 사용하도록 개선합니다.

- add isNull wrapper
- add null filter in include/exclude
- add test
- bump 0.0.10